### PR TITLE
Created a proof of concept for parsing Notion markdown into regular markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 
 .venv/
 .ruff_cache/
+.vscode/

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -1,0 +1,24 @@
+# Extensions
+
+## Markdown-to-Pelican
+
+The main purpose of this project was to help me compile my Notion into 
+Pelican-compliant markdown. This includes having a metadata section at the top
+of the file.
+
+This isn't _true_, portable markdown with this metadata. Hence I've decided to
+keep it out of scope of this project. However it would be a nice extension to 
+this project (potentially) where you can choose a compilation target and utilise
+these additional features of each target.
+
+But we can always have a markdown-to-pelican compiler anyway in the future.
+
+## Notion JSON to Markdown
+
+We have to make a lot of "guesses" and hacks to get the Notion markdown to work
+exactly as we expect. We might have a better time of it all if we instead use
+the **JSON** information of Notion pages.
+
+This JSON document is much better structured and means we don't really need to
+do any parsing of the original markdown but, instead, can just focus on compiling
+the JSON into a more concise markdown format.

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ dev = file: dev-requirements.txt
 
 [options.entry_points]
 console_scripts =
-    n2md = n2md.main:cli
+    n2md = n2md.cli:cli
 
 [options.packages.find]
 where = src/

--- a/src/n2md/__init__.py
+++ b/src/n2md/__init__.py
@@ -1,1 +1,3 @@
 __version__ = "0.0.0"
+
+from .converter import convert

--- a/src/n2md/cli.py
+++ b/src/n2md/cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import typer
 
-from .converter import convert
+from n2md import convert
 
 cli = typer.Typer()
 

--- a/src/n2md/converter.py
+++ b/src/n2md/converter.py
@@ -55,6 +55,6 @@ def _fix_headings(notion: str) -> str:
             flags=re.MULTILINE,
         )
 
-    notion = notion.replace("##", "#", 1)  # The first occurance goes back to H1
+    notion = notion.replace("## ", "# ", 1)  # The first occurance goes back to H1
 
     return notion

--- a/src/n2md/converter.py
+++ b/src/n2md/converter.py
@@ -9,7 +9,13 @@ import re
 
 def convert(notion: str) -> str:
     """Converts Notion export to pure Markdown."""
-    return notion  # TODO
+    output = str(notion)
+
+    ...
+    output = _remove_extra_stars(output)
+    ...
+
+    return output
 
 
 ################
@@ -26,5 +32,29 @@ def _remove_extra_stars(notion: str) -> str:
             notion = notion.replace(match, "*")
         else:  # even numbered stars (i.e. bold)
             notion = notion.replace(match, "**")
+
+    return notion
+
+
+def _fix_headings(notion: str) -> str:
+    """Fixes the heading levels.
+
+    The page title in Notion is expressed as a heading 1 (`#`), but so are the
+    top-level headings. This function fixes that by adding a `#` to all headings
+    except for the first occurance (i.e. the title).
+    """
+
+    for n in range(4, 0, -1):
+        pattern = r"^#{" + str(n) + r"} "  # e.g. `^#{3} `
+        repl = "#" * (n + 1) + " "  # e.g. `### `
+
+        notion = re.sub(
+            pattern=pattern,
+            repl=repl,
+            string=notion,
+            flags=re.MULTILINE,
+        )
+
+    notion = notion.replace("##", "#", 1)  # The first occurance goes back to H1
 
     return notion

--- a/src/n2md/converter.py
+++ b/src/n2md/converter.py
@@ -1,6 +1,30 @@
 """Defines the conversion algorithm."""
 
+import re
+
+###################
+## Main Function ##
+###################
+
 
 def convert(notion: str) -> str:
     """Converts Notion export to pure Markdown."""
     return notion  # TODO
+
+
+################
+## Converters ##
+################
+
+
+def _remove_extra_stars(notion: str) -> str:
+    """Removes superfluous star characters (`*`) from the Notion export."""
+    matches = re.findall(r"\*{3,}", notion)
+
+    for match in matches:
+        if len(match) % 2 == 1:  # odd numbered stars (i.e. italics)
+            notion = notion.replace(match, "*")
+        else:  # even numbered stars (i.e. bold)
+            notion = notion.replace(match, "**")
+
+    return notion

--- a/src/n2md/converter.py
+++ b/src/n2md/converter.py
@@ -11,9 +11,9 @@ def convert(notion: str) -> str:
     """Converts Notion export to pure Markdown."""
     output = str(notion)
 
-    ...
+    output = _fix_headings(output)
     output = _remove_extra_stars(output)
-    ...
+    output = _convert_callouts_to_quotes(output)
 
     return output
 
@@ -56,5 +56,20 @@ def _fix_headings(notion: str) -> str:
         )
 
     notion = notion.replace("## ", "# ", 1)  # The first occurance goes back to H1
+
+    return notion
+
+
+def _convert_callouts_to_quotes(notion: str) -> str:
+    """Converts Notion callouts to quotes."""
+    callouts = re.findall(r"<aside>(.*?)<\/aside>", notion, re.DOTALL)
+
+    for content in callouts:
+        content: str
+
+        original = f"<aside>{content}</aside>"
+        reformatted = "> " + content.strip("\n").replace("\n", "\n> ")
+
+        notion = notion.replace(original, reformatted)
 
     return notion

--- a/tests/data/markdown.md
+++ b/tests/data/markdown.md
@@ -2,6 +2,8 @@
 
 > 💡 This page exists for the purpose of testing the Notion Markdown → Regular markdown converter.
 
+> 💡 Here is a second callout for good measure.
+
 ## Heading 1
 
 ### Heading 2

--- a/tests/data/markdown.md
+++ b/tests/data/markdown.md
@@ -1,0 +1,47 @@
+# Notion Markdown Example
+
+> 💡 This page exists for the purpose of testing the Notion Markdown → Regular markdown converter.
+
+## Heading 1
+
+### Heading 2
+
+#### Heading 3
+
+Paragraph with plain text.
+
+Paragraph with **formatted** text, such as *italics* or underlines. We can also do a ***mix*** of formatting.
+
+An inline [link](https://google.com).
+
+Oh did I forget that you can have emojis too? 😛 and inline `code blocks` around standard text.
+
+We can also divide our page into sections.
+
+---
+
+If we so please.
+
+- Unordered
+- List
+- Items.
+
+1. Ordered
+2. list
+3. items.
+
+- [ ]  Checkable
+- [ ]  List
+- [ ]  Items
+
+> We can also form quotes. These quotes can contain **formatted text** ***also***.
+
+```python
+def code_block() -> str:
+    return "Hello from my code block!"
+```
+
+|  | A | B | C |
+| --- | --- | --- | --- |
+| 1 | A1 | B1 | C1 |
+| 2 | A2 | B2 | C2 |

--- a/tests/data/markdown.md
+++ b/tests/data/markdown.md
@@ -10,7 +10,7 @@
 
 Paragraph with plain text.
 
-Paragraph with **formatted** text, such as *italics* or underlines. We can also do a ***mix*** of formatting.
+Paragraph with **formatted** text, such as *italics* or underlines. We can also do a *mix* of formatting.
 
 An inline [link](https://google.com).
 
@@ -34,7 +34,7 @@ If we so please.
 - [ ]  List
 - [ ]  Items
 
-> We can also form quotes. These quotes can contain **formatted text** ***also***.
+> We can also form quotes. These quotes can contain **formatted text** *also*.
 
 ```python
 def code_block() -> str:

--- a/tests/data/notion.md
+++ b/tests/data/notion.md
@@ -5,6 +5,11 @@
 
 </aside>
 
+<aside>
+💡 Here is a second callout for good measure.
+
+</aside>
+
 # Heading 1
 
 ## Heading 2

--- a/tests/data/notion.md
+++ b/tests/data/notion.md
@@ -38,7 +38,6 @@ If we so please.
 - [ ]  Items
 
 > We can also form quotes. These quotes can contain ****************************formatted text**************************** *****also*****.
-> 
 
 ```python
 def code_block() -> str:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,12 @@
+"""Validates the converter algorithm behaves."""
+
+from pathlib import Path
+
+import n2md
+
+
+def test_converter(notion: Path, markdown: Path):
+    notion_md = notion.read_text()
+    regular_md = markdown.read_text()
+
+    assert n2md.convert(notion_md) == regular_md

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -9,7 +9,6 @@ import n2md
 from n2md import converter
 
 
-@pytest.mark.xfail
 def test_converter(notion: Path, markdown: Path):
     notion_md = notion.read_text()
     regular_md = markdown.read_text()

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2,11 +2,29 @@
 
 from pathlib import Path
 
+import pytest
+
 import n2md
+from n2md import converter
 
 
+@pytest.mark.xfail
 def test_converter(notion: Path, markdown: Path):
     notion_md = notion.read_text()
     regular_md = markdown.read_text()
 
     assert n2md.convert(notion_md) == regular_md
+
+
+@pytest.mark.parametrize(
+    "original, clean",
+    [
+        ("*bold*", "*bold*"),
+        ("**bold**", "**bold**"),
+        ("***bold***", "*bold*"),
+        ("****bold****", "**bold**"),
+        ("*****bold*****", "*bold*"),
+    ],
+)
+def test_removing_superfluous_stars(original: str, clean: str):
+    assert converter._remove_extra_stars(original) == clean

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -53,3 +53,43 @@ def test_fixing_headings():
     ).strip("\n")
 
     assert converter._fix_headings(original) == expected
+
+
+def test_converting_callouts_to_quotes():
+    original = dedent(
+        """
+        <aside>
+        This is a callout.
+        </aside>
+        """
+    ).strip("\n")
+
+    expected = dedent(
+        """
+        > This is a callout.
+        """
+    ).strip("\n")
+
+    assert converter._convert_callouts_to_quotes(original) == expected
+
+
+def test_converting_callouts_to_quotes_multiple_times():
+    original = dedent(
+        """
+        <aside>
+        This is a callout.
+        </aside>
+        <aside>
+        This is another callout.
+        </aside>
+        """
+    ).strip("\n")
+
+    expected = dedent(
+        """
+        > This is a callout.
+        > This is another callout.
+        """
+    ).strip("\n")
+
+    assert converter._convert_callouts_to_quotes(original) == expected

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,5 +1,6 @@
 """Validates the converter algorithm behaves."""
 
+from textwrap import dedent
 from pathlib import Path
 
 import pytest
@@ -28,3 +29,27 @@ def test_converter(notion: Path, markdown: Path):
 )
 def test_removing_superfluous_stars(original: str, clean: str):
     assert converter._remove_extra_stars(original) == clean
+
+
+def test_fixing_headings():
+    original = dedent(
+        """
+        # Title
+
+        # Heading 1
+        ## Heading 2
+        ### Heading 3
+        """
+    ).strip("\n")
+
+    expected = dedent(
+        """
+        # Title
+
+        ## Heading 1
+        ### Heading 2
+        #### Heading 3
+        """
+    ).strip("\n")
+
+    assert converter._fix_headings(original) == expected

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,5 +1,0 @@
-"""Collection of E2E tests to validate the package works as expected."""
-
-
-def test_e2e():
-    raise NotImplementedError


### PR DESCRIPTION
Done using a raw export of Notion markdown.

I'm aware this tool probably doesn't support _all_ edge cases of Notion. However, as an MVP, it's a good starting point.

I'm also aware that this convertor isn't lossless, as some information is lost in the conversion such as:

- Underlines (they don't even appear in the export).
- Composed formatting, such as simultaneous bolds and italics.